### PR TITLE
 Implementation to 'message Posting function'

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,29 @@
 class MessagesController < ApplicationController
-  def index
-  end
+  before_action :set_group
   
+  def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:text, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -11,19 +11,19 @@
       = link_to "#", class: "edit-page" do
         edit
   .message_list
-    .comment
-      .comment__listname
-        ksk
-        .comment__listname__time
-          2020/05/16(Sat)00:00:00
-      .comment__talk
-        こんつは
+    = render @messages
+      .comment
+        .comment__listname
+          ksk
+          .comment__listname__time
+            2020/05/16(Sat)00:00:00
+        .comment__talk
+          こんつは
   .message-form
-    %form.new_message
+    = form_for [@group, @message] do |f|
       .input-box
-        %input{type: "text", class: "input-box__text", placeholder: "type a message"}
-        %label{type: "text", class: "input-box__image"}
-          = icon('fas','image')
-          %input{type: "file", class: "input-box__image__file"}
-      %input{type: "submit", class: "submit-btn", value: "Send"}
-        
+      = f.text_field :text, class: 'input-box__text', placeholder: 'type a message'
+        = f.label :image, class: 'input-box__image' do
+          = icon('fas','image',)
+          = f.file_field :image, class: 'input-box__hidden'
+      = f.submit 'Send', class: 'submit-btn'


### PR DESCRIPTION
#what
メッセージ投稿機能の実装。
#why
コントローラーにアクションを記載し、
フォーム自体のビューを実装。メッセージを保存できる様にする。
form_forの活用。