### PR TITLE
remake auto-reloading-system

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,6 +5,7 @@ class GroupsController < ApplicationController
   end
 
   def new
+    binding.pry
     @group = Group.new
     @group.users << current_user
   end
@@ -36,6 +37,7 @@ class GroupsController < ApplicationController
   end
 
   def set_group
+    
     @group = Group.find(params[:id])
   end
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -9,7 +9,7 @@
         - @group.users.each do |user|
           = user.name
     .main-chat__mainheader__editbtn
-      = link_to edit_group_path(current_user), class: "edit-page" do
+      = link_to edit_group_path(@group), class: "edit-page" do
         edit
   .message_list
     = render @messages

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -3,7 +3,7 @@
     .account-page__inner--left.account-page__header
       %h2 Edit Account
       %h5 アカウントの編集
-      = link_to "ログアウト", 'destroy_user_session_path', method: :delete, class: 'btn'
+      = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
       = link_to "トップページに戻る", :back, class: 'btn'
     .account-page__inner--right.user-form
       = form_for(current_user) do |f|


### PR DESCRIPTION
# what
自動更新機能、グループ編集のミスがあったため、修正報告。
# why
グループ編集時に、なぜかcurrent_userのid が引き出されていたことが原因。

>_form.html.haml
```
= link_to edit_group_path(current_user), class: "edit-page" do
```
(current_user)を、(@group)に修正。
これで解決した。